### PR TITLE
Replaced transpose conv with bilinear interpolation

### DIFF
--- a/model.py
+++ b/model.py
@@ -22,15 +22,17 @@ class ConvBlock(nn.Module):
         return x
 
 class Up(nn.Module):
-    '''An upsampling block that applies a transposed convolution to upsample the input, 
+    '''An upsampling block that applies bilinear interpolation to upsample the input,
     concatenates it with the corresponding skip connection, and applies a convolutional block.'''
     def __init__(self, in_ch: int, skip_ch: int, out_ch: int):
         super().__init__()
-        self.up = nn.ConvTranspose2d(in_ch, in_ch // 2, 2, stride=2)
+        self.up = nn.Upsample(scale_factor=2, mode="bilinear", align_corners=False)
+        self.proj = nn.Conv2d(in_ch, in_ch // 2, kernel_size=1, bias=False)
         self.conv = ConvBlock(in_ch // 2 + skip_ch, out_ch)
 
     def forward(self, x, skip):
         x = self.up(x)
+        x = self.proj(x)
         x = torch.cat([x, skip], dim=1)
         return self.conv(x)
 


### PR DESCRIPTION
This pull request updates the upsampling strategy in the `Up` block of `model.py` to use bilinear interpolation instead of transposed convolution, and introduces a projection layer for channel adjustment before concatenation. These changes improve the quality and flexibility of upsampling in the model.

**Upsampling improvements:**

* Replaced transposed convolution (`nn.ConvTranspose2d`) with bilinear interpolation (`nn.Upsample`) for upsampling in the `Up` block, which can reduce checkerboard artifacts, improve output smoothness and enhance learning while decreasing memory.
* Added a projection layer (`nn.Conv2d` with kernel size 1) after upsampling to adjust channel dimensions before concatenating with the skip connection, ensuring correct input shape for the subsequent convolutional block.